### PR TITLE
0.5.5

### DIFF
--- a/dist/evcc-card.js
+++ b/dist/evcc-card.js
@@ -8,7 +8,7 @@
  *                /config/www/evcc-card/locales/en.json
  */
 
-const EVCC_CARD_VERSION = "0.5.3";
+const EVCC_CARD_VERSION = "0.5.5";
 
 const FEATURES = [
   { suffix: "mode",                domain: "select",        type: "mode",          lp: true  },

--- a/dist/evcc-card.js
+++ b/dist/evcc-card.js
@@ -28,6 +28,9 @@ const FEATURES = [
 
   { suffix: "charge_power",        domain: "sensor",        type: "power",         lp: true  },
   { suffix: "charge_current",      domain: "sensor",        type: "current",       lp: true  },
+  { suffix: "charge_currents_0",   domain: "sensor",        type: "current",       lp: true  },
+  { suffix: "charge_currents_1",   domain: "sensor",        type: "current",       lp: true  },
+  { suffix: "charge_currents_2",   domain: "sensor",        type: "current",       lp: true  },
   { suffix: "charge_duration",     domain: "sensor",        type: "info",          lp: true  },
   { suffix: "charged_energy",      domain: "sensor",        type: "energy",        lp: true  },
   { suffix: "effective_limit_soc", domain: "sensor",        type: "info",          lp: true  },
@@ -718,15 +721,41 @@ class EvccCard extends HTMLElement {
 
   _renderPowerRow(ents, charging) {
     if (!ents.charge_power) return "";
-    const power   = parseFloat(stateVal(this._hass, ents.charge_power)).toFixed(1);
-    const unit    = unitStr(this._hass, ents.charge_power);
-    const current = ents.charge_current
+    const power = parseFloat(stateVal(this._hass, ents.charge_power)).toFixed(1);
+    const unit  = unitStr(this._hass, ents.charge_power);
+
+    // Phasenstrom-Sensoren (echte Messwerte, standardmäßig deaktiviert)
+    const hasPhaseCurrents = ents.charge_currents_0 || ents.charge_currents_1 || ents.charge_currents_2;
+    const phaseCurrents = hasPhaseCurrents
+      ? [0, 1, 2].map(i => {
+          const val = ents[`charge_currents_${i}`]
+            ? parseFloat(stateVal(this._hass, ents[`charge_currents_${i}`]))
+            : null;
+          return (val === null || isNaN(val)) ? null : val;
+        })
+      : null;
+
+    // Fallback: offeredCurrent (wenn keine Phasenstrom-Sensoren vorhanden)
+    const current = !hasPhaseCurrents && ents.charge_current
       ? stateVal(this._hass, ents.charge_current) : null;
-    const phases  = ents.phases_active
+
+    // Phasen-Label nur wenn keine Einzelwerte sichtbar
+    const phases = !hasPhaseCurrents && ents.phases_active
       ? parseInt(stateVal(this._hass, ents.phases_active)) || null : null;
     const phasesLabel = phases === 1 ? this._t("phasesSingle")
                       : phases === 3 ? this._t("phasesTriple")
                       : phases !== null ? `${phases}` : null;
+
+    // Nur Phasen mit Strom > 0 anzeigen (robust gegen beliebige Phase-Belegung)
+    const activePhases = phaseCurrents ? phaseCurrents.filter(v => v !== null && v > 0) : null;
+    const phaseStr = activePhases && activePhases.length > 0
+      ? activePhases.map(v => Math.round(v)).join(" / ") + " A"
+      : null;
+
+    // Hinweis wenn offeredCurrent gezeigt wird (keine Phasenstrom-Entities verfügbar)
+    const hint = current !== null
+      ? `<div class="power-currents-hint">${this._t("phaseCurrentsHint")}</div>`
+      : "";
 
     return `
       <div class="power-row ${charging ? "charging" : ""}">
@@ -734,9 +763,11 @@ class EvccCard extends HTMLElement {
               data-live-entity="${ents.charge_power}" data-live-type="power">
           ${power} ${unit}
         </span>
+        ${phaseStr ? `<span class="power-sep">·</span><span class="power-current">${phaseStr}</span>` : ""}
         ${current !== null ? `<span class="power-sep">·</span><span class="power-current">${current} A</span>` : ""}
         ${phasesLabel !== null ? `<span class="power-sep">·</span><span class="power-phases">${phasesLabel}</span>` : ""}
       </div>
+      ${hint}
     `;
   }
 
@@ -3103,6 +3134,7 @@ class EvccCard extends HTMLElement {
       .power-sep { font-size: .8rem; color: var(--secondary-text-color); align-self: flex-end; padding-bottom: .2rem; }
       .power-current { font-size: .82rem; align-self: flex-end; padding-bottom: .2rem; }
       .power-phases  { font-size: .82rem; align-self: flex-end; padding-bottom: .2rem; }
+      .power-currents-hint { font-size: .72rem; color: var(--secondary-text-color, #757575); margin-top: 2px; opacity: .8; }
 
       .sliders { margin-bottom: 10px; }
       .slider-row { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; font-size: .83rem; flex-wrap: wrap; }

--- a/dist/evcc-card.js
+++ b/dist/evcc-card.js
@@ -1371,7 +1371,30 @@ class EvccCard extends HTMLElement {
 
     const SVG_ICON_HALF = 12;
 
-    const topBraces = segsWithX.map(s => {
+    // PV-Segmente (seg-pv + seg-pv-surplus) zu einer gemeinsamen Klammer zusammenführen
+    const topBraceGroups = [];
+    let ti = 0;
+    while (ti < segsWithX.length) {
+      const s = segsWithX[ti];
+      if (s.cls === "seg-pv" || s.cls === "seg-pv-surplus") {
+        let tj = ti;
+        while (tj < segsWithX.length &&
+               (segsWithX[tj].cls === "seg-pv" || segsWithX[tj].cls === "seg-pv-surplus")) tj++;
+        const grp = segsWithX.slice(ti, tj);
+        topBraceGroups.push({
+          x0: grp[0].x0,
+          x1: grp[grp.length - 1].x1,
+          xMid: (grp[0].x0 + grp[grp.length - 1].x1) / 2,
+          srcPath: MDI.solar,
+        });
+        ti = tj;
+      } else {
+        topBraceGroups.push(s);
+        ti++;
+      }
+    }
+
+    const topBraces = topBraceGroups.map(s => {
       const path  = bracePath(s.x0 + 2, s.x1 - 2, BAR_Y, TOP_TIP_Y);
       const ix = s.xMid - SVG_ICON_HALF, iy = TOP_TIP_Y - SVG_ICON_HALF;
       return `

--- a/dist/locales/de.json
+++ b/dist/locales/de.json
@@ -86,5 +86,6 @@
   "solar": "Solar",
   "battery": "Batterie",
   "total": "gesamt",
-  "solarHint": "☀️ Solar-Aufschlüsselung verfügbar sobald mehr Verlaufsdaten vorliegen ({n} von mind. 3 Tagen)."
+  "solarHint": "☀️ Solar-Aufschlüsselung verfügbar sobald mehr Verlaufsdaten vorliegen ({n} von mind. 3 Tagen).",
+  "phaseCurrentsHint": "Phasenstrom-Sensoren in HA aktivieren für genaue Stromwerte"
 }

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -86,5 +86,6 @@
   "solar": "Solar",
   "battery": "Battery",
   "total": "total",
-  "solarHint": "☀️ Solar breakdown available once more history is collected ({n} of min. 3 days)."
+  "solarHint": "☀️ Solar breakdown available once more history is collected ({n} of min. 3 days).",
+  "phaseCurrentsHint": "Enable phase current sensors in HA for accurate values"
 }

--- a/dist/locales/es.json
+++ b/dist/locales/es.json
@@ -86,5 +86,6 @@
   "solar": "Solar",
   "battery": "Batería",
   "total": "total",
-  "solarHint": "☀️ Desglose solar disponible cuando haya más datos históricos ({n} de mín. 3 días)."
+  "solarHint": "☀️ Desglose solar disponible cuando haya más datos históricos ({n} de mín. 3 días).",
+  "phaseCurrentsHint": "Activar sensores de corriente de fase en HA para valores precisos"
 }

--- a/dist/locales/fr.json
+++ b/dist/locales/fr.json
@@ -86,5 +86,6 @@
   "solar": "Solaire",
   "battery": "Batterie",
   "total": "total",
-  "solarHint": "☀️ Répartition solaire disponible dès que plus d'historique sera disponible ({n} sur min. 3 jours)."
+  "solarHint": "☀️ Répartition solaire disponible dès que plus d'historique sera disponible ({n} sur min. 3 jours).",
+  "phaseCurrentsHint": "Activer les capteurs de courant de phase dans HA pour des valeurs précises"
 }

--- a/dist/locales/hr.json
+++ b/dist/locales/hr.json
@@ -86,5 +86,6 @@
   "solar": "Solar",
   "battery": "Baterija",
   "total": "ukupno",
-  "solarHint": "☀️ Raščlamba solarne energije dostupna kada bude više podataka ({n} od min. 3 dana)."
+  "solarHint": "☀️ Raščlamba solarne energije dostupna kada bude više podataka ({n} od min. 3 dana).",
+  "phaseCurrentsHint": "Aktivirajte senzore fazne struje u HA za točne vrijednosti"
 }

--- a/dist/locales/nl.json
+++ b/dist/locales/nl.json
@@ -86,5 +86,6 @@
   "solar": "Zonne",
   "battery": "Batterij",
   "total": "totaal",
-  "solarHint": "☀️ Zonne-uitsplitsing beschikbaar zodra er meer historische gegevens zijn ({n} van min. 3 dagen)."
+  "solarHint": "☀️ Zonne-uitsplitsing beschikbaar zodra er meer historische gegevens zijn ({n} van min. 3 dagen).",
+  "phaseCurrentsHint": "Schakel fasestromsensoren in HA in voor nauwkeurige waarden"
 }

--- a/dist/locales/pl.json
+++ b/dist/locales/pl.json
@@ -86,5 +86,6 @@
   "solar": "Solar",
   "battery": "Akumulator",
   "total": "łącznie",
-  "solarHint": "☀️ Podział słoneczny dostępny gdy będzie więcej danych historycznych ({n} z min. 3 dni)."
+  "solarHint": "☀️ Podział słoneczny dostępny gdy będzie więcej danych historycznych ({n} z min. 3 dni).",
+  "phaseCurrentsHint": "Włącz czujniki prądu fazowego w HA dla dokładnych wartości"
 }

--- a/dist/locales/pt.json
+++ b/dist/locales/pt.json
@@ -86,5 +86,6 @@
   "solar": "Solar",
   "battery": "Bateria",
   "total": "total",
-  "solarHint": "☀️ Detalhamento solar disponível quando houver mais dados históricos ({n} de mín. 3 dias)."
+  "solarHint": "☀️ Detalhamento solar disponível quando houver mais dados históricos ({n} de mín. 3 dias).",
+  "phaseCurrentsHint": "Ativar sensores de corrente de fase no HA para valores precisos"
 }


### PR DESCRIPTION
What's changed                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                     
  - Fix: Vehicle select (#93) — Corrected vehicle selection behavior                                                                                                                                                                                                                 
  - Fix: Sun bracket rendering (#95) — PV self-consumption and surplus segments are now covered by a single bracket with one solar icon instead of a broken empty bracket                                                                                                            
  - Fix: Phase current display (#94) — The card now shows real per-phase currents (charge_currents_0/1/2) instead of offeredCurrent. If the sensors are not yet enabled in HA, a small hint guides users to activate them